### PR TITLE
Feature/web minor tweaks

### DIFF
--- a/08-Authors.md
+++ b/08-Authors.md
@@ -27,7 +27,7 @@ This project would not be possible without the help of [our amazing contributors
 
 We very much welcome new contributors to the TGMPA library. To get you started, please read the [contributing guidelines].
 
-If you want to translate the TGMPA library, please download the `.pot` file from the `/languages/` directory in the `develop` branch. Once you have finished your translation, please submit a pull request with your the `.po` (and `.mo`) file(s).
+If you want to translate the TGMPA library, please download the [`tgmpa.pot`] file from the `/languages/` directory in the `develop` branch. Once you have finished your translation, please submit a pull request with your the `.po` (and `.mo`) file(s).
 
 If you want to contribute to or translate this website, please read the separate [gh-pages readme] and [gh-pages contributing guidelines].
 
@@ -35,5 +35,6 @@ If you want to contribute to or translate this website, please read the separate
 [Thomas Griffin]: https://thomasgriffin.io
 [our amazing contributors]: {{ '/graphs/contributors' | prepend: site.tgmpa.github }}
 [contributing guidelines]: {{ '/blob/develop/CONTRIBUTING.md' | prepend: site.tgmpa.github }}
+[`tgmpa.pot`]: {{ '/develop/languages/tgmpa.pot' | prepend: site.tgmpa.github }}
 [gh-pages readme]: {{ '/blob/gh-pages/README.md' | prepend: site.tgmpa.github }}
 [gh-pages contributing guidelines]: {{ '/blob/gh-pages/CONTRIBUTING.md' | prepend: site.tgmpa.github }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,7 @@
 <html lang="en">
 {% include header.html %}
 
-	{% unless page.anchor == "home" or page.anchor == "blog" %}
+	{% unless page.anchor == "home" or page.anchor == "blog" or page.menu == false %}
 	{% include tweet-button.html %}
 	{% endunless %}
 

--- a/css/style.css
+++ b/css/style.css
@@ -368,7 +368,7 @@ div#download table {
     margin: 0.3em 0;
     padding-right: 5px;
     vertical-align: top;
-    width: 19%;
+    width: 165px;
 	font-size: 90%;
 }
 .contributor img {


### PR DESCRIPTION
* Prevent contributor blocks from wrapping by giving the block a fixed width - might need to adjust the actual width later again depending on the length of contributor nicknames, but should be more stable than the % version
* The 404 page contained the tweet button which did not seem very useful ;-) Removed
* Make the reference to the .pot file a link to the raw file on GH so people can download the file straight away.
