### PR TITLE
Fix 'update' link always showing in notice…

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -1038,9 +1038,10 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				}
 
 				if ( ! $this->is_plugin_installed( $slug ) ) {
-					$install_link_count++;
 
 					if ( current_user_can( 'install_plugins' ) ) {
+						$install_link_count++;
+
 						if ( true === $plugin['required'] ) {
 							$message['notice_can_install_required'][] = $slug;
 						} else {
@@ -1052,9 +1053,10 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					}
 				} else {
 					if ( ! $this->is_plugin_active( $slug ) && $this->can_plugin_activate( $slug ) ) {
-						$activate_link_count++;
 
 						if ( current_user_can( 'activate_plugins' ) ) {
+							$activate_link_count++;
+
 							if ( true === $plugin['required'] ) {
 								$message['notice_can_activate_required'][] = $slug;
 							} else {
@@ -1066,13 +1068,11 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 						}
 					}
 
-					if ( $this->does_plugin_require_update( $slug ) && false === $this->does_plugin_have_update( $slug ) ) {
-						continue;
-
-					} else {
-						$update_link_count++;
+					if ( $this->does_plugin_require_update( $slug ) || false !== $this->does_plugin_have_update( $slug ) ) {
 
 						if ( current_user_can( 'install_plugins' ) ) {
+							$update_link_count++;
+
 							if ( $this->does_plugin_require_update( $slug ) ) {
 								$message['notice_ask_to_update'][] = $slug;
 							} elseif ( false !== $this->does_plugin_have_update( $slug ) ) {
@@ -1169,6 +1169,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				$action_links = apply_filters( 'tgmpa_notice_action_links', $action_links );
 
 				$action_links = array_filter( (array) $action_links ); // Remove any empty array items.
+
 				if ( ! empty( $action_links ) && is_array( $action_links ) ) {
 					$action_links = sprintf( $line_template, implode( ' | ', $action_links ) );
 					$rendered    .= apply_filters( 'tgmpa_notice_rendered_action_links', $action_links );
@@ -1220,7 +1221,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			if ( isset( $_GET['tgmpa-dismiss'] ) ) {
 				update_user_meta( get_current_user_id(), 'tgmpa_dismissed_notice_' . $this->id, 1 );
 			}
-
 		}
 
 		/**
@@ -2120,6 +2120,11 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 			// Prep variables for use and grab list of all installed plugins.
 			$table_data = array();
 			$i          = 0;
+
+			// Redirect to the 'all' view if no plugins where found for the selected view context.
+			if ( empty( $plugins[ $this->view_context ] ) ) {
+				$this->view_context = 'all';
+			}
 
 			foreach ( $plugins[ $this->view_context ] as $slug => $plugin ) {
 


### PR DESCRIPTION
... even when no updates available.

Also: redirect to 'all' view when selected view does not have any plugins to display.

Re bug reported over skype:
> Gary Jones: Only thing is that Begin updating plugins link in the admin notice - when there are none to update. Clicking that gives you an empty table, and a notice that there are "No plugins to install, update, or activate", yet the filter links above says "All (4) | To Install (2) | To Activate (2)". A bit confusing.
Or, if there's nothing to update, we redirect to showing All instead.
![screenshot](https://photos-1.dropbox.com/t/2/AAASDdmGhTqQd3wFXEOJolaX8hSlXP2OiYy_ECQeEJjQmw/12/1532009/png/32x32/1/1434265200/0/2/Screenshot%202015-06-12%2007.55.47.png/COnAXSABIAIgAyAEIAUgBiAHKAEoAigH/SCjezr-6VQXvaNj5Yid6YwzypWAEHqLgQLEbpydyM50?size=1024x768&size_mode=2)
