### PR TITLE
Code tidy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,38 +10,38 @@ language: php
 
 # Declare versions of PHP to use. Use one decimal max.
 php:
-    - 5.2
-    - 5.6
-    - hhvm
+  - 5.2
+  - 5.6
+  - hhvm
 
 matrix:
-    allow_failures:
-        - php: hhvm
+  allow_failures:
+    - php: hhvm
 
 before_script:
-    - export PHPCS_DIR=/tmp/phpcs
-    - export WPCS_DIR=/tmp/wpcs
-    # Install CodeSniffer for WordPress Coding Standards checks.
-    # 2.3.1 breaks PHP 5.2 on Travis due to use of Phar class.
-    - git clone -b 2.3.0 --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR
-    # Install WordPress Coding Standards.
-    - git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR
-    # Set install path for WordPress Coding Standards.
-    # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-    - $PHPCS_DIR/scripts/phpcs --config-set installed_paths $WPCS_DIR
-    # After CodeSniffer install you should refresh your path.
-    - phpenv rehash
+  - export PHPCS_DIR=/tmp/phpcs
+  - export WPCS_DIR=/tmp/wpcs
+  # Install CodeSniffer for WordPress Coding Standards checks.
+  # 2.3.1 breaks PHP 5.2 on Travis due to use of Phar class.
+  - git clone -b 2.3.0 --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR
+  # Install WordPress Coding Standards.
+  - git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $WPCS_DIR
+  # Set install path for WordPress Coding Standards.
+  # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
+  - $PHPCS_DIR/scripts/phpcs --config-set installed_paths $WPCS_DIR
+  # After CodeSniffer install you should refresh your path.
+  - phpenv rehash
 
 # Run test script commands.
 # All commands must exit with code 0 on success. Anything else is considered failure.
 script:
-    # Search for PHP syntax errors.
-    - find . \( -name '*.php' \) -exec php -lf {} \;
-    # WordPress Coding Standards
-    # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
-    # @link https://github.com/squizlabs/PHP_CodeSniffer
-    # All of the usual config flags are held in phpcs.xml
-    - $PHPCS_DIR/scripts/phpcs
+  # Search for PHP syntax errors.
+  - find . \( -name '*.php' \) -exec php -lf {} \;
+  # WordPress Coding Standards
+  # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+  # @link https://github.com/squizlabs/PHP_CodeSniffer
+  # All of the usual config flags are held in phpcs.xml
+  - $PHPCS_DIR/scripts/phpcs
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for TGM Plugin Activation library
 
-## 2.5.0 (2015-06-12)
+## 2.5.0-RC (2015-07-??)
 
 This is a major update which brings some interesting new features and fixes tons of bugs. This version of TGMPA is brought to you by [Thomas Griffin] with graceful thanks to [Gary Jones] and our new core-team member [Juliette Reinders Folmer] for the majority of the changes.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Lead Developers:**
 [Thomas Griffin](https://github.com/thomasgriffin) ([@jthomasgriffin](https://twitter.com/jthomasgriffin)), [Gary Jones](https://github.com/GaryJones) ([@GaryJ](https://twitter.com/GaryJ)), [Juliette Reinders Folmer](https://github.com/jrfnl) ([@jrf_nl](https://twitter.com/jrf_nl))  
-**Version:** 2.5.0  
+**Version:** 2.5.0-RC  
 **Requires at least:** 3.7.0  
 **Tested up to:** 4.2.0  
 

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -8,7 +8,7 @@
  * or theme author for support.
  *
  * @package   TGM-Plugin-Activation
- * @version   2.5.0
+ * @version   2.5.0-RC
  * @link      http://tgmpluginactivation.com/
  * @author    Thomas Griffin, Gary Jones, Juliette Reinders Folmer
  * @copyright Copyright (c) 2011, Thomas Griffin
@@ -18,8 +18,8 @@
  * Plugin Name: TGM Plugin Activation
  * Plugin URI:
  * Description: Plugin installation and activation for WordPress themes.
- * Version:     2.5.0
- * Author:      griffinjt, garyj, jrf
+ * Version:     2.5.0-RC
+ * Author:      Thomas Griffin, Gary Jones, Juliette Reinders Folmer
  * Author URI:  http://tgmpluginactivation.com/
  * Text Domain: tgmpa
  * Domain Path: /languages/
@@ -59,7 +59,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 	 * @author  Gary Jones
 	 */
 	class TGM_Plugin_Activation {
-
 		/**
 		 * TGMPA version number.
 		 *
@@ -262,7 +261,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @see TGM_Plugin_Activation::init()
 		 */
 		protected function __construct() {
-
 			// Set the current WordPress version.
 			$this->wp_version = $GLOBALS['wp_version'];
 
@@ -271,7 +269,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 
 			// When the rest of WP has loaded, kick-start the rest of the class.
 			add_action( 'init', array( $this, 'init' ) );
-
 		}
 
 		/**
@@ -286,7 +283,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @see TGM_Plugin_Activation::styles()
 		 */
 		public function init() {
-
 			/**
 			 * By default TGMPA only loads on the WP back-end and not in an Ajax call. Using this filter
 			 * you can overrule that behaviour.
@@ -356,7 +352,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					'Begin installing plugins',
 					'tgmpa'
 				),
-				'update_link' 					  => _n_noop(
+				'update_link'                     => _n_noop(
 					'Begin updating plugin',
 					'Begin updating plugins',
 					'tgmpa'
@@ -366,7 +362,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					'Begin activating plugins',
 					'tgmpa'
 				),
-
 				'return'                          => __( 'Return to Required Plugins Installer', 'tgmpa' ),
 				'dashboard'                       => __( 'Return to the dashboard', 'tgmpa' ),
 				'plugin_activated'                => __( 'Plugin activated successfully.', 'tgmpa' ),
@@ -406,7 +401,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				}
 
 				add_action( 'load-plugins.php', array( $this, 'add_plugin_action_link_filters' ), 1 );
-
 			}
 
 			// Make sure things get reset on switch theme.
@@ -425,7 +419,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			if ( true === $this->has_forced_deactivation ) {
 				add_action( 'switch_theme', array( $this, 'force_deactivation' ) );
 			}
-
 		}
 
 		/**
@@ -457,11 +450,11 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param array $actions Action links.
-		 *
 		 * @return array
 		 */
 		public function filter_plugin_action_links_activate( $actions ) {
 			unset( $actions['activate'] );
+
 			return $actions;
 		}
 
@@ -471,11 +464,11 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param array $actions Action links.
-		 *
 		 * @return array
 		 */
 		public function filter_plugin_action_links_deactivate( $actions ) {
 			unset( $actions['deactivate'] );
+
 			return $actions;
 		}
 
@@ -486,7 +479,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param array $actions Action links.
-		 *
 		 * @return array
 		 */
 		public function filter_plugin_action_links_update( $actions ) {
@@ -496,6 +488,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				esc_attr__( 'This plugin needs to be updated to be compatible with your theme.', 'tgmpa' ),
 				esc_html__( 'Update Required', 'tgmpa' )
 			);
+
 			return $actions;
 		}
 
@@ -523,7 +516,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @return null Returns early if not the TGMPA page.
 		 */
 		public function admin_init() {
-
 			if ( ! $this->is_tgmpa_page() ) {
 				return;
 			}
@@ -544,7 +536,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 
 				exit;
 			}
-
 		}
 
 		/**
@@ -559,11 +550,9 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.1.0
 		 */
 		public function thickbox() {
-
 			if ( ! get_user_meta( get_current_user_id(), 'tgmpa_dismissed_notice_' . $this->id, true ) ) {
 				add_thickbox();
 			}
-
 		}
 
 		/**
@@ -578,9 +567,10 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 *
 		 * @see TGM_Plugin_Activation::init()
 		 * @see TGM_Plugin_Activation::install_plugins_page()
+		 *
+		 * @return null Return early if user lacks capability to install a plugin.
 		 */
 		public function admin_menu() {
-
 			// Make sure privileges are correct to see the page.
 			if ( ! current_user_can( 'install_plugins' ) ) {
 				return;
@@ -599,7 +589,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			);
 
 			$this->add_admin_menu( $args );
-
 		}
 
 		/**
@@ -616,7 +605,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 
 			if ( 'themes.php' === $this->parent_slug ) {
 				$this->page_hook = call_user_func( 'add_theme_page', $args['page_title'], $args['menu_title'], $args['capability'], $args['menu_slug'], $args['function'] );
-
 			} else {
 				$this->page_hook = call_user_func( 'add_submenu_page', $args['parent_slug'], $args['page_title'], $args['menu_title'], $args['capability'], $args['menu_slug'], $args['function'] );
 			}
@@ -634,7 +622,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @return null Aborts early if we're processing a plugin installation action.
 		 */
 		public function install_plugins_page() {
-
 			// Store new instance of plugin table in object.
 			$plugin_table = new TGMPA_List_Table;
 
@@ -665,7 +652,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				</form>
 			</div>
 			<?php
-
 		}
 
 		/**
@@ -689,7 +675,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @return boolean True on success, false on failure.
 		 */
 		protected function do_plugin_install() {
-
 			if ( empty( $_GET['plugin'] ) ) {
 				return false;
 			}
@@ -769,7 +754,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				if ( 'update' === $install_type ) {
 					$skin_args['plugin'] = $this->plugins[ $slug ]['file_path'];
 					$skin                = new Plugin_Upgrader_Skin( $skin_args );
-
 				} else {
 					$skin = new Plugin_Installer_Skin( $skin_args );
 				}
@@ -787,7 +771,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					$this->inject_update_info( $to_inject );
 
 					$upgrader->upgrade( $this->plugins[ $slug ]['file_path'] );
-
 				} else {
 					$upgrader->install( $source );
 				}
@@ -812,12 +795,11 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				if ( $this->is_tgmpa_complete() ) {
 					echo '<p>', sprintf( esc_html( $this->strings['complete'] ), '<a href="' . esc_url( self_admin_url() ) . '">' . esc_html__( 'Return to the Dashboard', 'tgmpa' ) . '</a>' ), '</p>';
 					echo '<style type="text/css">#adminmenu .wp-submenu li.current { display: none !important; }</style>';
-
 				} else {
 					echo '<p><a href="', esc_url( $this->get_tgmpa_url() ), '" target="_parent">', esc_html( $this->strings['return'] ), '</a></p>';
 				}
-				return true;
 
+				return true;
 			} elseif ( isset( $this->plugins[ $slug ]['file_path'], $_GET['tgmpa-activate'] ) && 'activate-plugin' === $_GET['tgmpa-activate'] ) {
 				// Activate action link was clicked.
 				check_admin_referer( 'tgmpa-activate', 'tgmpa-nonce' );
@@ -828,7 +810,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			}
 
 			return false;
-
 		}
 
 		/**
@@ -839,7 +820,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @param array $plugins The plugin information for the plugins which are to be updated.
 		 */
 		public function inject_update_info( $plugins ) {
-
 			$repo_updates = get_site_transient( 'update_plugins' );
 
 			if ( ! is_object( $repo_updates ) ) {
@@ -847,7 +827,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			}
 
 			foreach ( $plugins as $slug => $plugin ) {
-
 				$file_path = $plugin['file_path'];
 
 				if ( empty( $repo_updates->response[ $file_path ] ) ) {
@@ -881,11 +860,9 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @param string       $source        Path to upgrade/zip-file-name.tmp/subdirectory/.
 		 * @param string       $remote_source Path to upgrade/zip-file-name.tmp.
 		 * @param \WP_Upgrader $upgrader      Instance of the upgrader which installs the plugin.
-		 *
 		 * @return string $source
 		 */
 		public function maybe_adjust_source_dir( $source, $remote_source, $upgrader ) {
-
 			if ( ! $this->is_tgmpa_page() || ! is_object( $GLOBALS['wp_filesystem'] ) ) {
 				return $source;
 			}
@@ -893,7 +870,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			// Check for single file plugins.
 			$source_files = array_keys( $GLOBALS['wp_filesystem']->dirlist( $remote_source ) );
 			if ( 1 === count( $source_files ) && false === $GLOBALS['wp_filesystem']->is_dir( $source ) ) {
-
 				return $source;
 			}
 
@@ -923,10 +899,8 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 
 					if ( true === $GLOBALS['wp_filesystem']->move( $from, $to ) ) {
 						return trailingslashit( $to );
-
 					} else {
 						return new WP_Error( 'rename_failed', esc_html__( 'The remote plugin package does not contain a folder with the desired slug and renaming did not work.', 'tgmpa' ) . ' ' . esc_html__( 'Please contact the plugin provider and ask them to package their plugin according to the WordPress guidelines.', 'tgmpa' ), array( 'found' => $subdir_name, 'expected' => $desired_slug ) );
-
 					}
 				} elseif ( empty( $subdir_name ) ) {
 					return new WP_Error( 'packaged_wrong', esc_html__( 'The remote plugin package consists of more than one file, but the files are not packaged in a folder.', 'tgmpa' ) . ' ' . esc_html__( 'Please contact the plugin provider and ask them to package their plugin according to the WordPress guidelines.', 'tgmpa' ), array( 'found' => $subdir_name, 'expected' => $desired_slug ) );
@@ -945,19 +919,17 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @param string $slug      Plugin slug.
 		 * @param bool   $automatic Whether this is an automatic activation after an install. Defaults to false.
 		 *                          This determines the styling of the output messages.
-		 *
 		 * @return bool False if an error was encountered, true otherwise.
 		 */
 		protected function activate_single_plugin( $file_path, $slug, $automatic = false ) {
-
 			if ( $this->can_plugin_activate( $slug ) ) {
 				$activate = activate_plugin( $file_path );
 
 				if ( is_wp_error( $activate ) ) {
 					echo '<div id="message" class="error"><p>', wp_kses_post( $activate->get_error_message() ), '</p></div>',
 						'<p><a href="', esc_url( $this->get_tgmpa_url() ), '" target="_parent">', esc_html( $this->strings['return'] ), '</a></p>';
-					return false; // End it here if there is an error with activation.
 
+					return false; // End it here if there is an error with activation.
 				} else {
 					if ( ! $automatic ) {
 						// Make sure message doesn't display again if bulk activation is performed
@@ -979,7 +951,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 						'<strong>' . esc_html( $this->plugins[ $slug ]['name'] ) . '</strong>'
 					),
 					'</p></div>';
-
 			} elseif ( $this->does_plugin_require_update( $slug ) ) {
 				if ( ! $automatic ) {
 					// Make sure message doesn't display again if bulk activation is performed
@@ -1017,7 +988,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @return null Returns early if we're on the Install page.
 		 */
 		public function notices() {
-
 			// Remove nag on the install page / Return early if the nag message has been dismissed.
 			if ( $this->is_tgmpa_page() || get_user_meta( get_current_user_id(), 'tgmpa_dismissed_notice_' . $this->id, true ) ) {
 				return;
@@ -1032,13 +1002,11 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			$activate_link_count = 0;
 
 			foreach ( $this->plugins as $slug => $plugin ) {
-
 				if ( $this->is_plugin_active( $slug ) && false === $this->does_plugin_have_update( $slug ) ) {
 					continue;
 				}
 
 				if ( ! $this->is_plugin_installed( $slug ) ) {
-
 					if ( current_user_can( 'install_plugins' ) ) {
 						$install_link_count++;
 
@@ -1053,7 +1021,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					}
 				} else {
 					if ( ! $this->is_plugin_active( $slug ) && $this->can_plugin_activate( $slug ) ) {
-
 						if ( current_user_can( 'activate_plugins' ) ) {
 							$activate_link_count++;
 
@@ -1188,7 +1155,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			if ( 'options-general' !== $GLOBALS['current_screen']->parent_base ) {
 				$this->display_settings_errors();
 			}
-
 		}
 
 		/**
@@ -1217,7 +1183,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.1.0
 		 */
 		public function dismiss() {
-
 			if ( isset( $_GET['tgmpa-dismiss'] ) ) {
 				update_user_meta( get_current_user_id(), 'tgmpa_dismissed_notice_' . $this->id, 1 );
 			}
@@ -1231,7 +1196,8 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param array $plugin Array of plugin arguments.
+		 * @param array|null $plugin Array of plugin arguments or null if invalid argument.
+		 * @return null Return early if incorrect argument.
 		 */
 		public function register( $plugin ) {
 			if ( empty( $plugin['slug'] ) || empty( $plugin['name'] ) ) {
@@ -1293,17 +1259,13 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 *
 		 * @param string $source The source of the plugin as provided, either empty (= WP repo), a file path
 		 *                       (= bundled) or an external URL.
-		 *
 		 * @return string 'repo', 'external', or 'bundled'
 		 */
 		protected function get_plugin_source_type( $source ) {
-
 			if ( 'repo' === $source || preg_match( self::WP_REPO_REGEX, $source ) ) {
 				return 'repo';
-
 			} elseif ( preg_match( self::IS_URL_REGEX, $source ) ) {
 				return 'external';
-
 			} else {
 				return 'bundled';
 			}
@@ -1346,7 +1308,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @param array $config Array of config options to pass as class properties.
 		 */
 		public function config( $config ) {
-
 			$keys = array(
 				'id',
 				'default_path',
@@ -1370,7 +1331,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					}
 				}
 			}
-
 		}
 
 		/**
@@ -1379,18 +1339,15 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.0.0
 		 *
 		 * @param array $install_actions Existing array of actions.
-		 *
 		 * @return array Amended array of actions.
 		 */
 		public function actions( $install_actions ) {
-
 			// Remove action links on the TGMPA install page.
 			if ( $this->is_tgmpa_page() ) {
 				return false;
 			}
 
 			return $install_actions;
-
 		}
 
 		/**
@@ -1403,9 +1360,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 *                                 Parameter added in v2.5.0.
 		 */
 		public function flush_plugins_cache( $clear_update_cache = true ) {
-
 			wp_clean_plugins_cache( $clear_update_cache );
-
 		}
 
 		/**
@@ -1417,17 +1372,14 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 *                            Parameter added in v2.5.0.
 		 */
 		public function populate_file_path( $plugin_slug = '' ) {
-
 			if ( ! empty( $plugin_slug ) && is_string( $plugin_slug ) && isset( $this->plugins[ $plugin_slug ] ) ) {
 				$this->plugins[ $plugin_slug ]['file_path'] = $this->_get_plugin_basename_from_slug( $plugin_slug );
-
 			} else {
 				// Add file_path key for all plugins.
 				foreach ( $this->plugins as $slug => $values ) {
 					$this->plugins[ $slug ]['file_path'] = $this->_get_plugin_basename_from_slug( $slug );
 				}
 			}
-
 		}
 
 		/**
@@ -1437,11 +1389,9 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.0.0
 		 *
 		 * @param string $slug Plugin slug (typically folder name) as provided by the developer.
-		 *
 		 * @return string Either file path for plugin if installed, or just the plugin slug.
 		 */
 		protected function _get_plugin_basename_from_slug( $slug ) {
-
 			$keys = array_keys( $this->get_plugins() );
 
 			foreach ( $keys as $key ) {
@@ -1451,7 +1401,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			}
 
 			return $slug;
-
 		}
 
 		/**
@@ -1464,11 +1413,9 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 *
 		 * @param string $name Name of the plugin, as it was registered.
 		 * @param string $data Optional. Array key of plugin data to return. Default is slug.
-		 *
 		 * @return string|boolean Plugin slug if found, false otherwise.
 		 */
 		public function _get_plugin_data_from_name( $name, $data = 'slug' ) {
-
 			foreach ( $this->plugins as $values ) {
 				if ( $name === $values['name'] && isset( $values[ $data ] ) ) {
 					return $values[ $data ];
@@ -1476,7 +1423,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			}
 
 			return false;
-
 		}
 
 		/**
@@ -1485,21 +1431,16 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $slug Plugin slug.
-		 *
 		 * @return string Plugin download URL or path to local file or empty string if undetermined.
 		 */
 		public function get_download_url( $slug ) {
-
 			$dl_source = '';
 
 			switch ( $this->plugins[ $slug ]['source_type'] ) {
-
 				case 'repo':
 					return $this->get_wp_repo_download_url( $slug );
-
 				case 'external':
 					return $this->plugins[ $slug ]['source'];
-
 				case 'bundled':
 					return $this->default_path . $this->plugins[ $slug ]['source'];
 			}
@@ -1513,11 +1454,9 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $slug Plugin slug.
-		 *
 		 * @return string Plugin download URL.
 		 */
 		protected function get_wp_repo_download_url( $slug ) {
-
 			$source = '';
 			$api    = $this->get_plugins_api( $slug );
 
@@ -1526,7 +1465,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			}
 
 			return $source;
-
 		}
 
 		/**
@@ -1535,14 +1473,12 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $slug Plugin slug.
-		 *
 		 * @return object Plugins_api response object on success, WP_Error on failure.
 		 */
 		protected function get_plugins_api( $slug ) {
 			static $api = array(); // Cache received responses.
 
 			if ( ! isset( $api[ $slug ] ) ) {
-
 				if ( ! function_exists( 'plugins_api' ) ) {
 					require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 				}
@@ -1567,19 +1503,16 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $slug Plugin slug.
-		 *
 		 * @return string Fully formed html link to a plugin information page if available
 		 *                or the plugin name if not.
 		 */
 		public function get_info_link( $slug ) {
-
 			if ( ! empty( $this->plugins[ $slug ]['external_url'] ) && preg_match( self::IS_URL_REGEX, $this->plugins[ $slug ]['external_url'] ) ) {
 				$link = sprintf(
 					'<a href="%1$s" target="_blank">%2$s</a>',
 					esc_url( $this->plugins[ $slug ]['external_url'] ),
 					esc_html( $this->plugins[ $slug ]['name'] )
 				);
-
 			} elseif ( 'repo' === $this->plugins[ $slug ]['source_type'] ) {
 				$url = add_query_arg(
 					array(
@@ -1597,7 +1530,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					esc_url( $url ),
 					esc_html( $this->plugins[ $slug ]['name'] )
 				);
-
 			} else {
 				$link = esc_html( $this->plugins[ $slug ]['name'] ); // No hyperlink.
 			}
@@ -1613,9 +1545,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @return boolean True when on the TGMPA page, false otherwise.
 		 */
 		protected function is_tgmpa_page() {
-
 			return isset( $_GET['page'] ) && $this->menu === $_GET['page'];
-
 		}
 
 		/**
@@ -1656,7 +1586,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $status Plugin status - either 'install', 'update' or 'activate'.
-		 *
 		 * @return string Properly encoded URL (not escaped).
 		 */
 		public function get_tgmpa_status_url( $status ) {
@@ -1693,11 +1622,11 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $slug Plugin slug.
-		 *
 		 * @return bool True if installed, false otherwise.
 		 */
 		public function is_plugin_installed( $slug ) {
 			$installed_plugins = $this->get_plugins(); // Retrieve a list of all installed plugins (WP cached).
+
 			return ( ! empty( $installed_plugins[ $this->plugins[ $slug ]['file_path'] ] ) );
 		}
 
@@ -1707,7 +1636,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $slug Plugin slug.
-		 *
 		 * @return bool True if active, false otherwise.
 		 */
 		public function is_plugin_active( $slug ) {
@@ -1721,11 +1649,9 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $slug Plugin slug.
-		 *
 		 * @return bool True if OK to update, false otherwise.
 		 */
 		public function can_plugin_update( $slug ) {
-
 			// We currently can't get reliable info on non-WP-repo plugins - issue #380.
 			if ( 'repo' !== $this->plugins[ $slug ]['source_type'] ) {
 				return true;
@@ -1748,7 +1674,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $slug Plugin slug.
-		 *
 		 * @return bool True if OK to activate, false otherwise.
 		 */
 		public function can_plugin_activate( $slug ) {
@@ -1761,12 +1686,10 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $slug Plugin slug.
-		 *
 		 * @return string Version number as string or an empty string if the plugin is not installed
 		 *                or version unknown (plugins which don't comply with the plugin header standard).
 		 */
 		public function get_installed_version( $slug ) {
-
 			$installed_plugins = $this->get_plugins(); // Retrieve a list of all installed plugins (WP cached).
 
 			if ( ! empty( $installed_plugins[ $this->plugins[ $slug ]['file_path'] ]['Version'] ) ) {
@@ -1782,7 +1705,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $slug Plugin slug.
-		 *
 		 * @return bool True when a plugin needs to be updated, otherwise false.
 		 */
 		public function does_plugin_require_update( $slug ) {
@@ -1798,16 +1720,15 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $slug Plugin slug.
-		 *
 		 * @return false|string Version number string of the available update or false if no update available.
 		 */
 		public function does_plugin_have_update( $slug ) {
-
 			// Presume bundled and external plugins will point to a package which meets the minimum required version.
 			if ( 'repo' !== $this->plugins[ $slug ]['source_type'] ) {
 				if ( $this->does_plugin_require_update( $slug ) ) {
 					return $this->plugins[ $slug ]['version'];
 				}
+
 				return false;
 			}
 
@@ -1826,11 +1747,9 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $slug Plugin slug.
-		 *
 		 * @return string The upgrade notice or an empty string if no message was available or provided.
 		 */
 		public function get_upgrade_notice( $slug ) {
-
 			// We currently can't get reliable info on non-WP-repo plugins - issue #380.
 			if ( 'repo' !== $this->plugins[ $slug ]['source_type'] ) {
 				return '';
@@ -1851,7 +1770,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $plugin_folder Optional. Relative path to single plugin folder.
-		 *
 		 * @return array Array of installed plugins with plugin information.
 		 */
 		public function get_plugins( $plugin_folder = '' ) {
@@ -1871,9 +1789,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.1.1
 		 */
 		public function update_dismiss() {
-
 			delete_metadata( 'user', null, 'tgmpa_dismissed_notice_' . $this->id, null, true );
-
 		}
 
 		/**
@@ -1891,21 +1807,17 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.2.0
 		 */
 		public function force_activation() {
-
 			foreach ( $this->plugins as $slug => $plugin ) {
 				if ( true === $plugin['force_activation'] ) {
-
 					if ( ! $this->is_plugin_installed( $slug ) ) {
 						// Oops, plugin isn't there so iterate to next condition.
 						continue;
-
 					} elseif ( $this->can_plugin_activate( $slug ) ) {
 						// There we go, activate the plugin.
 						activate_plugin( $plugin['file_path'] );
 					}
 				}
 			}
-
 		}
 
 		/**
@@ -1921,14 +1833,12 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @since 2.2.0
 		 */
 		public function force_deactivation() {
-
 			foreach ( $this->plugins as $slug => $plugin ) {
 				// Only proceed forward if the parameter is set to true and plugin is active.
 				if ( true === $plugin['force_deactivation'] && $this->is_plugin_active( $slug ) ) {
 					deactivate_plugins( $plugin['file_path'] );
 				}
 			}
-
 		}
 
 		/**
@@ -1948,15 +1858,12 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * @return object The TGM_Plugin_Activation object.
 		 */
 		public static function get_instance() {
-
 			if ( ! isset( self::$instance ) && ! ( self::$instance instanceof self ) ) {
 				self::$instance = new self();
 			}
 
 			return self::$instance;
-
 		}
-
 	}
 
 	if ( ! function_exists( 'load_tgm_plugin_activation' ) ) {
@@ -2028,7 +1935,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 	 * @author  Gary Jones
 	 */
 	class TGMPA_List_Table extends WP_List_Table {
-
 		/**
 		 * TGMPA instance.
 		 *
@@ -2060,7 +1966,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 			'update'   => 0,
 			'activate' => 0,
 		);
-
 
 		/**
 		 * References parent constructor and sets defaults for class.
@@ -2106,7 +2011,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @return array $table_data Information for use in table.
 		 */
 		protected function _gather_plugin_data() {
-
 			// Load thickbox for plugin links.
 			$this->tgmpa->admin_init();
 			$this->tgmpa->thickbox();
@@ -2127,7 +2031,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 			}
 
 			foreach ( $plugins[ $this->view_context ] as $slug => $plugin ) {
-
 				$table_data[ $i ]['sanitized_plugin']  = $plugin['name'];
 				$table_data[ $i ]['slug']              = $slug;
 				$table_data[ $i ]['plugin']            = '<strong>' . $this->tgmpa->get_info_link( $slug ) . '</strong>';
@@ -2152,7 +2055,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 			}
 
 			return $table_data;
-
 		}
 
 		/**
@@ -2161,7 +2063,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @since 2.5.0
 		 */
 		protected function categorize_plugins_to_views() {
-
 			$plugins = array(
 				'all'      => array(), // Meaning: all plugins which still have open actions.
 				'install'  => array(),
@@ -2170,17 +2071,14 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 			);
 
 			foreach ( $this->tgmpa->plugins as $slug => $plugin ) {
-
 				if ( $this->tgmpa->is_plugin_active( $slug ) && false === $this->tgmpa->does_plugin_have_update( $slug ) ) {
 					// No need to display plugins if they are installed, up-to-date and active.
 					continue;
-
 				} else {
 					$plugins['all'][ $slug ] = $plugin;
 
 					if ( ! $this->tgmpa->is_plugin_installed( $slug ) ) {
 						$plugins['install'][ $slug ] = $plugin;
-
 					} else {
 						if ( false !== $this->tgmpa->does_plugin_have_update( $slug ) ) {
 							$plugins['update'][ $slug ] = $plugin;
@@ -2204,7 +2102,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @param array $plugins Plugins order by view.
 		 */
 		protected function set_view_totals( $plugins ) {
-
 			foreach ( $plugins as $type => $list ) {
 				$this->view_totals[ $type ] = count( $list );
 			}
@@ -2216,11 +2113,9 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $required Plugin required setting.
-		 *
 		 * @return string
 		 */
 		protected function get_plugin_advise_type_text( $required ) {
-
 			if ( true === $required ) {
 				return __( 'Required', 'tgmpa' );
 			}
@@ -2234,7 +2129,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $type Plugin type.
-		 *
 		 * @return string
 		 */
 		protected function get_plugin_source_type_text( $type ) {
@@ -2244,11 +2138,9 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 				case 'repo':
 					$string = __( 'WordPress Repository', 'tgmpa' );
 					break;
-
 				case 'external':
 					$string = __( 'External Source', 'tgmpa' );
 					break;
-
 				case 'bundled':
 					$string = __( 'Pre-Packaged', 'tgmpa' );
 					break;
@@ -2263,11 +2155,9 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param string $slug Plugin slug.
-		 *
 		 * @return string
 		 */
 		protected function get_plugin_status_text( $slug ) {
-
 			if ( ! $this->tgmpa->is_plugin_installed( $slug ) ) {
 				return __( 'Not Installed', 'tgmpa' );
 			}
@@ -2307,11 +2197,9 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param array $items Prepared table items.
-		 *
 		 * @return array Sorted table items.
 		 */
 		public function sort_table_items( $items ) {
-
 			$type = array();
 			$name = array();
 
@@ -2323,7 +2211,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 			array_multisort( $type, SORT_DESC, $name, SORT_ASC, $items );
 
 			return $items;
-
 		}
 
 		/**
@@ -2334,7 +2221,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @return array
 		 */
 		public function get_views() {
-
 			$status_links = array();
 
 			foreach ( $this->view_totals as $type => $count ) {
@@ -2346,19 +2232,15 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 					case 'all':
 						$text = _nx( 'All <span class="count">(%s)</span>', 'All <span class="count">(%s)</span>', $count, 'plugins', 'tgmpa' );
 						break;
-
 					case 'install':
 						$text = _n( 'To Install <span class="count">(%s)</span>', 'To Install <span class="count">(%s)</span>', $count, 'tgmpa' );
 						break;
-
 					case 'update':
 						$text = _n( 'Update Available <span class="count">(%s)</span>', 'Update Available <span class="count">(%s)</span>', $count, 'tgmpa' );
 						break;
-
 					case 'activate':
 						$text = _n( 'To Activate <span class="count">(%s)</span>', 'To Activate <span class="count">(%s)</span>', $count, 'tgmpa' );
 						break;
-
 					default:
 						$text = '';
 						break;
@@ -2386,13 +2268,10 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 *
 		 * @param array  $item        Array of item data.
 		 * @param string $column_name The name of the column.
-		 *
 		 * @return string
 		 */
 		public function column_default( $item, $column_name ) {
-
 			return $item[ $column_name ];
-
 		}
 
 		/**
@@ -2403,18 +2282,15 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @since 2.2.0
 		 *
 		 * @param array $item Array of item data.
-		 *
-		 * @return string     The input checkbox with all necessary info.
+		 * @return string The input checkbox with all necessary info.
 		 */
 		public function column_cb( $item ) {
-
 			return sprintf(
 				'<input type="checkbox" name="%1$s[]" value="%2$s" id="%3$s" />',
 				esc_attr( $this->_args['singular'] ),
 				esc_attr( $item['slug'] ),
 				esc_attr( $item['sanitized_plugin'] )
 			);
-
 		}
 
 		/**
@@ -2423,11 +2299,9 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @since 2.2.0
 		 *
 		 * @param array $item Array of item data.
-		 *
-		 * @return string     The plugin name and action links.
+		 * @return string The plugin name and action links.
 		 */
 		public function column_plugin( $item ) {
-
 			return sprintf(
 				'%1$s %2$s',
 				$item['plugin'],
@@ -2441,11 +2315,9 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param array $item Array of item data.
-		 *
-		 * @return string     HTML-formatted version information.
+		 * @return string HTML-formatted version information.
 		 */
 		public function column_version( $item ) {
-
 			$output = array();
 
 			if ( $this->tgmpa->is_plugin_installed( $item['slug'] ) ) {
@@ -2500,10 +2372,8 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @since 2.2.0
 		 */
 		public function no_items() {
-
 			printf( wp_kses_post( __( 'No plugins to install, update or activate. <a href="%1$s">Return to the Dashboard</a>', 'tgmpa' ) ), esc_url( self_admin_url() ) );
 			echo '<style type="text/css">#adminmenu .wp-submenu li.current { display: none !important; }</style>';
-
 		}
 
 		/**
@@ -2514,7 +2384,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @return array $columns The column names.
 		 */
 		public function get_columns() {
-
 			$columns = array(
 				'cb'     => '<input type="checkbox" />',
 				'plugin' => __( 'Plugin', 'tgmpa' ),
@@ -2528,7 +2397,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 			}
 
 			return apply_filters( 'tgmpa_table_columns', $columns );
-
 		}
 
 		/**
@@ -2540,7 +2408,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @return string
 		 */
 		protected function get_default_primary_column_name() {
-		    return 'plugin';
+			return 'plugin';
 		}
 
 		/**
@@ -2552,7 +2420,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @return string The name of the primary column.
 		 */
 		protected function get_primary_column_name() {
-
 			if ( method_exists( 'WP_List_Table', 'get_primary_column_name' ) ) {
 				return parent::get_primary_column_name();
 			} else {
@@ -2566,29 +2433,23 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @since 2.5.0
 		 *
 		 * @param array $item Array of item data.
-		 *
-		 * @return array      Array with relevant action links.
+		 * @return array Array with relevant action links.
 		 */
 		protected function get_row_actions( $item ) {
-
 			$actions      = array();
 			$action_links = array();
 
 			// Display the 'Install' action link if the plugin is not yet available.
 			if ( ! $this->tgmpa->is_plugin_installed( $item['slug'] ) ) {
-
 				$actions['install'] = _x( 'Install %2$s', '%2$s = plugin name in screen reader markup', 'tgmpa' );
-
 			} else {
 				// Display the 'Update' action link if an update is available and WP complies with plugin minimum.
 				if ( false !== $this->tgmpa->does_plugin_have_update( $item['slug'] ) && $this->tgmpa->can_plugin_update( $item['slug'] ) ) {
-
 					$actions['update'] = _x( 'Update %2$s', '%2$s = plugin name in screen reader markup', 'tgmpa' );
 				}
 
 				// Display the 'Activate' action link, but only if the plugin meets the minimum version.
 				if ( $this->tgmpa->can_plugin_activate( $item['slug'] ) ) {
-
 					$actions['activate'] = _x( 'Activate %2$s', '%2$s = plugin name in screen reader markup', 'tgmpa' );
 				}
 			}
@@ -2626,7 +2487,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @param object $item The current item.
 		 */
 		public function single_row( $item ) {
-
 			parent::single_row( $item );
 
 			/**
@@ -2649,9 +2509,9 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 *
 		 * @param string $slug Plugin slug.
 		 * @param array  $item The information available in this table row.
+		 * @return null Return early if upgrade notice is empty.
 		 */
 		public function wp_plugin_update_row( $slug, $item ) {
-
 			if ( empty( $item['upgrade_notice'] ) ) {
 				return;
 			}
@@ -2718,7 +2578,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @since 2.2.0
 		 */
 		public function process_bulk_actions() {
-
 			// Bulk installation process.
 			if ( 'tgmpa-bulk-install' === $this->current_action() || 'tgmpa-bulk-update' === $this->current_action() ) {
 
@@ -2740,12 +2599,12 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 					}
 
 					echo '<div id="message" class="error"><p>', esc_html( $message ), '</p></div>';
+
 					return false;
 				}
 
 				if ( is_array( $_POST['plugin'] ) ) {
 					$plugins_to_install = (array) $_POST['plugin'];
-
 				} elseif ( is_string( $_POST['plugin'] ) ) {
 					// Received via Filesystem page - un-flatten array (WP bug #19643).
 					$plugins_to_install = explode( ',', $_POST['plugin'] );
@@ -2778,6 +2637,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 					}
 
 					echo '<div id="message" class="error"><p>', esc_html( $message ), '</p></div>';
+
 					return false;
 				}
 
@@ -2794,13 +2654,14 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 				$fields = array_keys( $_POST ); // Extra fields to pass to WP_Filesystem.
 
 				if ( false === ( $creds = request_filesystem_credentials( esc_url_raw( $url ), $method, false, false, $fields ) ) ) {
-				   	return true; // Stop the normal page form from displaying, credential request form will be shown.
+					return true; // Stop the normal page form from displaying, credential request form will be shown.
 				}
 
 				// Now we have some credentials, setup WP_Filesystem.
 				if ( ! WP_Filesystem( $creds ) ) {
 					// Our credentials were no good, ask the user for them again.
 					request_filesystem_credentials( esc_url_raw( $url ), $method, true, false, $fields );
+
 					return true;
 				}
 
@@ -2873,12 +2734,12 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 
 			// Bulk activation process.
 			if ( 'tgmpa-bulk-activate' === $this->current_action() ) {
-
 				check_admin_referer( 'bulk-' . $this->_args['plural'] );
 
 				// Did user actually select any plugins to activate ?
 				if ( empty( $_POST['plugin'] ) ) {
 					echo '<div id="message" class="error"><p>', esc_html__( 'No plugins were selected to be activated. No action taken.', 'tgmpa' ), '</p></div>';
+
 					return false;
 				}
 
@@ -2904,6 +2765,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 				// Return early if there are no plugins to activate.
 				if ( empty( $plugins_to_activate ) ) {
 					echo '<div id="message" class="error"><p>', esc_html__( 'No plugins are available to be activated at this time.', 'tgmpa' ), '</p></div>';
+
 					return false;
 				}
 
@@ -2912,7 +2774,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 
 				if ( is_wp_error( $activate ) ) {
 					echo '<div id="message" class="error"><p>', wp_kses_post( $activate->get_error_message() ), '</p></div>';
-
 				} else {
 					$count        = count( $plugin_names ); // Count so we can use _n function.
 					$plugin_names = array_map( array( 'TGM_Utils', 'wrap_in_strong' ), $plugin_names );
@@ -2933,7 +2794,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 						}
 					}
 					update_option( 'recently_activated', $recent );
-
 				}
 
 				unset( $_POST ); // Reset the $_POST variable in case user wants to perform one action after another.
@@ -2950,7 +2810,6 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @since 2.2.0
 		 */
 		public function prepare_items() {
-
 			$columns               = $this->get_columns(); // Get all necessary column information.
 			$hidden                = array(); // No columns to hide, but we must set as an array.
 			$sortable              = array(); // No reason to make sortable columns.
@@ -2964,9 +2823,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 
 			// Store all of our plugin data into $items array so WP_List_Table can use it.
 			$this->items = apply_filters( 'tgmpa_table_data_items', $this->_gather_plugin_data() );
-
 		}
-
 
 		/* *********** DEPRECATED METHODS *********** */
 
@@ -2979,14 +2836,13 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 *
 		 * @param string $name Name of the plugin, as it was registered.
 		 * @param string $data Optional. Array key of plugin data to return. Default is slug.
-		 *
 		 * @return string|boolean Plugin slug if found, false otherwise.
 		 */
 		protected function _get_plugin_data_from_name( $name, $data = 'slug' ) {
 			_deprecated_function( __FUNCTION__, 'TGMPA 2.5.0', 'TGM_Plugin_Activation::_get_plugin_data_from_name()' );
+
 			return $this->tgmpa->_get_plugin_data_from_name( $name, $data );
 		}
-
 	}
 }
 
@@ -3010,7 +2866,6 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 		$tgmpa_instance = call_user_func( array( get_class( $GLOBALS['tgmpa'] ), 'get_instance' ) );
 
 		if ( isset( $_GET['page'] ) && $tgmpa_instance->menu === $_GET['page'] ) {
-
 			if ( ! class_exists( 'Plugin_Upgrader', false ) ) {
 				require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 			}
@@ -3032,7 +2887,6 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 				 * @author  Gary Jones
 				 */
 				class TGM_Bulk_Installer extends Plugin_Upgrader {
-
 					/**
 					 * Holds result of bulk plugin installation.
 					 *
@@ -3099,7 +2953,6 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 					 * @since 2.2.0
 					 */
 					public function activate_strings() {
-
 						$this->strings['activation_failed']  = __( 'Plugin activation failed.', 'tgmpa' );
 						$this->strings['activation_success'] = __( 'Plugin activated successfully.', 'tgmpa' );
 					}
@@ -3112,7 +2965,6 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 					 * @see WP_Upgrader::run()
 					 *
 					 * @param array $options The installation config options.
-					 *
 					 * @return null|array Return early if error, array of installation data on success.
 					 */
 					public function run( $options ) {
@@ -3145,11 +2997,9 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 					 *
 					 * @param array $plugins The plugin sources needed for installation.
 					 * @param array $args    Arbitrary passed extra arguments.
-					 *
 					 * @return string|bool Install confirmation messages on success, false on failure.
 					 */
 					public function bulk_install( $plugins, $args = array() ) {
-
 						// [TGMPA + ] Hook auto-activation in.
 						add_filter( 'upgrader_post_install', array( $this, 'auto_activate' ), 10 );
 
@@ -3173,6 +3023,7 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 						$res = $this->fs_connect( array( WP_CONTENT_DIR, WP_PLUGIN_DIR ) );
 						if ( ! $res ) {
 							$this->skin->footer();
+
 							return false;
 						}
 
@@ -3288,7 +3139,6 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 					 *
 					 * @param array $plugins The local WP file_path's of the plugins which should be upgraded.
 					 * @param array $args    Arbitrary passed extra arguments.
-					 *
 					 * @return string|bool Install confirmation messages on success, false on failure.
 					 */
 					public function bulk_upgrade( $plugins, $args = array() ) {
@@ -3310,14 +3160,11 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 					 * @since 2.5.0
 					 *
 					 * @param bool $bool The value we need to give back (true).
-					 *
 					 * @return bool
 					 */
 					public function auto_activate( $bool ) {
-
 						// Only process the activation of installed plugins if the automatic flag is set to true.
 						if ( $this->tgmpa->is_automatic ) {
-
 							// Flush plugins cache so the headers of the newly installed plugins will be read correctly.
 							wp_clean_plugins_cache();
 
@@ -3334,7 +3181,6 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 								if ( is_wp_error( $activate ) ) {
 									$this->skin->error( $activate );
 									$this->strings['process_success'] .= $this->strings['activation_failed'];
-
 								} else {
 									$this->strings['process_success'] .= $this->strings['activation_success'];
 								}
@@ -3363,7 +3209,6 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 				 * @author  Gary Jones
 				 */
 				class TGM_Bulk_Installer_Skin extends Bulk_Upgrader_Skin {
-
 					/**
 					 * Holds plugin info for each individual plugin installation.
 					 *
@@ -3425,7 +3270,6 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 
 						// Extract the new args.
 						parent::__construct( $args );
-
 					}
 
 					/**
@@ -3440,9 +3284,7 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 						if ( 'update' === $this->options['install_type'] ) {
 							parent::add_strings();
 							$this->upgrader->strings['skin_before_update_header'] = __( 'Updating Plugin %1$s (%2$d/%3$d)', 'tgmpa' );
-
 						} else {
-
 							$this->upgrader->strings['skin_update_failed_error'] = __( 'An error occurred while installing %1$s: <strong>%2$s</strong>.', 'tgmpa' );
 							$this->upgrader->strings['skin_update_failed']       = __( 'The installation of %1$s failed.', 'tgmpa' );
 
@@ -3452,7 +3294,6 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 								$this->upgrader->strings['skin_update_successful']    = __( '%1$s installed and activated successfully.', 'tgmpa' ) . ' <a href="#" class="hide-if-no-js" onclick="%2$s"><span>' . esc_html__( 'Show Details', 'tgmpa' ) . '</span><span class="hidden">' . esc_html__( 'Hide Details', 'tgmpa' ) . '</span>.</a>';
 								$this->upgrader->strings['skin_upgrade_end']          = __( 'All installations and activations have been completed.', 'tgmpa' );
 								$this->upgrader->strings['skin_before_update_header'] = __( 'Installing and Activating Plugin %1$s (%2$d/%3$d)', 'tgmpa' );
-
 							} else {
 								// Default installation strings.
 								$this->upgrader->strings['skin_upgrade_start']        = __( 'The installation process is starting. This process may take a while on some hosts, so please be patient.', 'tgmpa' );
@@ -3502,7 +3343,6 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 					 * @since 2.2.0
 					 */
 					public function bulk_footer() {
-
 						// Serve up the string to say installations (and possibly activations) are complete.
 						parent::bulk_footer();
 
@@ -3570,10 +3410,8 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 				}
 			}
 		}
-
 	}
 }
-
 
 if ( ! class_exists( 'TGM_Utils' ) ) {
 
@@ -3588,7 +3426,6 @@ if ( ! class_exists( 'TGM_Utils' ) ) {
 	 * @author  Juliette Reinders Folmer
 	 */
 	class TGM_Utils {
-
 		/**
 		 * Whether the PHP filter extension is enabled.
 		 *
@@ -3602,7 +3439,6 @@ if ( ! class_exists( 'TGM_Utils' ) ) {
 		 */
 		public static $has_filters;
 
-
 		/**
 		 * Wrap an arbitrary string in <em> tags. Meant to be used in combination with array_map().
 		 *
@@ -3611,7 +3447,6 @@ if ( ! class_exists( 'TGM_Utils' ) ) {
 		 * @static
 		 *
 		 * @param string $string Text to be wrapped.
-		 *
 		 * @return string
 		 */
 		public static function wrap_in_em( $string ) {
@@ -3626,7 +3461,6 @@ if ( ! class_exists( 'TGM_Utils' ) ) {
 		 * @static
 		 *
 		 * @param string $string Text to be wrapped.
-		 *
 		 * @return string
 		 */
 		public static function wrap_in_strong( $string ) {
@@ -3641,7 +3475,6 @@ if ( ! class_exists( 'TGM_Utils' ) ) {
 		 * @static
 		 *
 		 * @param mixed $value Arbitrary value.
-		 *
 		 * @return bool
 		 */
 		public static function validate_bool( $value ) {
@@ -3651,7 +3484,6 @@ if ( ! class_exists( 'TGM_Utils' ) ) {
 
 			if ( self::$has_filters ) {
 				return filter_var( $value, FILTER_VALIDATE_BOOLEAN );
-
 			} else {
 				return self::emulate_filter_bool( $value );
 			}
@@ -3665,11 +3497,9 @@ if ( ! class_exists( 'TGM_Utils' ) ) {
 		 * @static
 		 *
 		 * @param mixed $value Value to cast.
-		 *
 		 * @return bool
 		 */
 		protected static function emulate_filter_bool( $value ) {
-
 			// @codingStandardsIgnoreStart
 			static $true  = array(
 				'1',
@@ -3689,29 +3519,22 @@ if ( ! class_exists( 'TGM_Utils' ) ) {
 
 			if ( is_bool( $value ) ) {
 				return $value;
-
 			} else if ( is_int( $value ) && ( 0 === $value || 1 === $value ) ) {
 				return (bool) $value;
-
 			} else if ( ( is_float( $value ) && ! is_nan( $value ) ) && ( (float) 0 === $value || (float) 1 === $value ) ) {
 				return (bool) $value;
-
 			} else if ( is_string( $value ) ) {
-
 				$value = trim( $value );
 				if ( in_array( $value, $true, true ) ) {
 					return true;
-
 				} else if ( in_array( $value, $false, true ) ) {
 					return false;
-
 				} else {
 					return false;
 				}
 			}
+
 			return false;
 		}
-
 	} // End of class TGM_Utils
-
 } // End of class_exists wrapper

--- a/composer.json
+++ b/composer.json
@@ -1,34 +1,34 @@
 {
-    "name": "tgmpa/tgm-plugin-activation",
-    "description": "TGM Plugin Activation is a PHP library that allows you to easily require or recommend plugins for your WordPress themes (and plugins).",
-    "homepage": "http://tgmpluginactivation.com",
-    "keywords": ["wordpress","plugins", "theme", "library", "activation"],
-    "license": "GPL-2.0+",
-    "authors": [
-        {
-            "name": "Thomas Griffin",
-            "homepage": "http://thomasgriffinmedia.com",
-            "role": "Developer"
-        },
-        {
-            "name": "Gary Jones",
-            "homepage": "https://github.com/GaryJones",
-            "role": "Developer"
-        },
-        {
-            "name": "Juliette Reinders Folmer",
-            "homepage": "https://github.com/jrfnl",
-            "role": "Developer"
-        }
-    ],
-    "support": {
-        "issues": "https://github.com/TGMPA/TGM-Plugin-Activation/issues",
-        "source": "https://github.com/TGMPA/TGM-Plugin-Activation"
+  "name": "tgmpa/tgm-plugin-activation",
+  "description": "TGM Plugin Activation is a PHP library that allows you to easily require or recommend plugins for your WordPress themes (and plugins).",
+  "homepage": "http://tgmpluginactivation.com",
+  "keywords": ["wordpress","plugins", "theme", "library", "activation"],
+  "license": "GPL-2.0+",
+  "authors": [
+    {
+      "name": "Thomas Griffin",
+      "homepage": "http://thomasgriffinmedia.com",
+      "role": "Developer"
     },
-    "require": {
-        "php": ">=5.2"
+    {
+      "name": "Gary Jones",
+      "homepage": "https://github.com/GaryJones",
+      "role": "Developer"
     },
-    "autoload": {
-        "files": ["class-tgm-plugin-activation.php"]
+    {
+      "name": "Juliette Reinders Folmer",
+      "homepage": "https://github.com/jrfnl",
+      "role": "Developer"
     }
+  ],
+  "support": {
+    "issues": "https://github.com/TGMPA/TGM-Plugin-Activation/issues",
+    "source": "https://github.com/TGMPA/TGM-Plugin-Activation"
+  },
+  "require": {
+    "php": ">=5.2"
+  },
+  "autoload": {
+    "files": ["class-tgm-plugin-activation.php"]
+  }
 }

--- a/example.php
+++ b/example.php
@@ -23,7 +23,6 @@
 require_once dirname( __FILE__ ) . '/class-tgm-plugin-activation.php';
 
 add_action( 'tgmpa_register', 'my_theme_register_required_plugins' );
-
 /**
  * Register the required plugins for this theme.
  *
@@ -198,5 +197,4 @@ function my_theme_register_required_plugins() {
 	);
 
 	tgmpa( $plugins, $config );
-
 }


### PR DESCRIPTION
* Remove redundant clear lines when changing to a different level of indentation.
* Add a clear line before `return` when it follows other code at the same level of indentation.
* Fix or add some missing `@return` docs.
* Change plugin headers to use real names.
* Change version to `-RC` since we're not yet ready to tag.
* Remove space between `@param` and `@return` per WP coding standards.
* Remove incorrect alignment of some `@return` descriptions.