### PR TITLE
Changelog for release 2.6.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,54 @@
 # Changelog for TGM Plugin Activation library
 
+## 2.6.0 (2016-05-14)
+
+Since mid-February we offer a _"Custom TGMPA Generator"_. From now on, that is the preferred way for downloading your copy of TGMPA for use in a theme or plugin.
+If you download TGMPA using the _Custom TGMPA Generator_ and indicate that it is for a theme which will be published on wordpress.org, you will receive a copy which will pass the Theme Check review.
+
+You can find the _Custom TGMPA Generator_ on the [download] page of the website. For more information, read the [related blog post].
+
+* **Bug fixes**:
+  - Fixed minor/low-impact security vulnerability. Thanks [Mohamed A. Baset] for reporting. If *you* find a security vulnerability, please disclose responsibly! [#487], [#505]
+  - Fixed a bug where action links on the WP native plugins page would not be properly filtered. [#458], [#459]
+  - Fixed a bug where TGMPA when included within a plugin would be recognized as the plugin instead of the *real* plugin. Thanks [weavertheme] and [Mika Epstein] for reporting. [#499], [#500], [#558]
+  - Fixed an install error when trying to bulk-install an already installed plugin. Thanks [Ahmad Awais] for reporting. [#496], [#504]
+  - Fixed an update error when trying to bulk-update a plugin which is not installed. Thanks [Gary Jones] for reporting. [#442], [#508]
+  - Fixed admin notices display class. Props [Ninos Ego] and [Primoz Cigler]. [#478], [#495], [#509]
+  - Fixed an issue resulting in notices about installed/updated plugins on the bulk install/update pages being displayed at the top of the page instead of inline. [#510], [#511]
+
+* **Enhancements**:
+  - The full admin notice is now only displayed to users who can install/update/activate plugins. A limited _"Contact the site admin."_ notice is shown to select users if it pertains to _required_ plugins. The selection of which users get to see this last message is based on the `publish_posts` (=Author) capability. This capability is however filterable using the new `tgmpa_show_admin_notice_capability` filter. Thanks [Stanislav Khromov], [Gary Jones], [Mickey Kay], [Ollie Treend] for suggesting. [#190], [#414], [#489], [#507]
+  - The example file now shows examples of different ways for including TGMPA based on the context in which you are using it. Props [Emil Uzelac] for the suggestion. [#469], [#503]
+  - Force deactivated plugins will now show in the 'recently active' plugins list. [#577]
+
+* **I18N improvements**:
+  - Improved some text strings and translator messages. Props [Rami]. [#516]
+  - Added translator messages for all strings with variable replacement.[#563]
+  - Added `load_textdomain()` calls. [#521]
+  - Added translations for Brazilian Portuguese, Croatian, Czech, Dutch, French, German, Russian and Swedish [#450], [#574], [#570], [#465], [#524], [#528], [#543], [#561] with grateful thanks to [Elvis Henrique Pereira], [Denis Žoljom], [Karolína Vyskočilová], [geoclaps], [Hedi Chaibi], [Marciel Bartzik], [Vladislav Burlak] and [Lewis Porter].
+    Additionally translations for Australian English, Canadian English, British English, Esperanto, Spanish, Hebrew, Italian, Romanian and Serbian were added based on existing translations available in GlotPress. [#564]
+
+    Altogether, this means that for the first version of TGMPA which ships with translation files, we're covering 17 locales, which is awesome!
+    More translations are of course welcome, so please send the .po file(s) in as a pull request.
+
+    _Please note: If you download TGMPA using the custom generator and indicate it's for a theme to be hosted on wordpress.org, you will receive a version without the `load_textdomain()` calls or the translation files.
+    Theme check rules dictate that you should only use one textdomain in your theme and the localization calls will be adjusted to use your theme's textdomain.
+	As most TGMPA strings have a lot of translations available in GlotPress already, this should not cause any real issues._
+
+* **Housekeeping**:
+  - Various other minor improvements and keeping things in line with WP core. [#512], [#513], [#514], [#532] - thanks [Utkarsh Patel], [#562], [#571]
+  - Updated the included example plugin to comply to the latest standards. [#557]
+  - Regenerated .pot file.
+
+
 ## 2.5.2 (2015-07-15)
-* Hot Fix: fixes potential `Fatal error: Call to protected TGM_Plugin_Activation::__construct()` error and other compatibility issues when both TGMPA 2.5+ as well as TGMPA 2.3.6- would be loaded by different themes and plugins.
+* Hot Fix: fixes potential `Fatal error: Call to protected TGM_Plugin_Activation::__construct()` error and other compatibility issues when both TGMPA 2.5+ as well as TGMPA 2.3.6- would be loaded by different themes and plugins. [#449]
 
 Take note: We do **NOT** support 2.3.6 anymore and **_highly_** discourage its use. Any themes and plugins still using TGMPA 2.3.6 or less should upgrade as soon as possible. All the same, the end-user should not be confronted with white screens because of it, so this hot fix should prevent just that.
 
 ## 2.5.1 (2015-07-13)
 
-* Hot Fix: fixes potential `Fatal error: Call to undefined method TGM_Utils::validate_bool()` errors caused by a conflict with the Soliloquy plugin.
+* Hot Fix: fixes potential `Fatal error: Call to undefined method TGM_Utils::validate_bool()` errors caused by a conflict with the Soliloquy plugin. [#446]
 
 ## 2.5.0 (2015-07-03)
 
@@ -28,11 +69,11 @@ TGMPA will start providing localized text strings soon. If you already have tran
     - If a plugin requires a certain minimum version of a plugin and the currently installed version does not comply, activation will be blocked until the user has upgraded the plugin. If the plugin is already active, it will not be deactivated however.
 		* If the required plugin version itself requires a higher WP version than the currently installed WP, upgrade to that version of the plugin will be blocked - this is of course provided TGMPA has access to that information -.
 	- The plugin action links on the WP native plugins page will reflect this too - including disabling deactivation if _force_activation_ is `true` for a plugin.
-	
+
 	[#381], [#192], [#197] Props [Zauan/Hogash Studio], [Christian], [Franklin Gitonga], [Jason Xie], [swiderski] for their preliminary work on this which inspired this full-fledged implementation.
 
 * Enhancement: **Better support for GitHub hosted plugins**.
-  
+
   Previously using standard GitHub packaged zips as download source would not work as, even though the plugin would be installed, it would not be recognized as such by TGMPA because of the non-standard directory name which would be created for the plugin, i.e. `my-plugin-master` instead of `my-plugin`. A work-around for this has been implemented and you can now use GitHub-packaged `master` branch or release zips to install plugins. Have a look at the `example.php` file for a working example.
 
   One caveat: this presumes that the plugin is based in the root of the GitHub repo and not in a `/src` or other subdirectory.
@@ -44,7 +85,7 @@ TGMPA will start providing localized text strings soon. If you already have tran
   Some plugins may have a free and a premium version using different slugs. Using the `is_callable` plugin parameter allows for the premium version to be recognized, even though the slug is set to the free version slug. Have a look at the `example.php` file for a working example.
 
   For more information on what is considered a `callable`, please refer to the [Codex on callbacks].
-  
+
   [#205] Props [Zack Katz].
 
 * **Admin Page improvements**:
@@ -67,6 +108,7 @@ TGMPA will start providing localized text strings soon. If you already have tran
 * **Miscellaneous fixes**:
   - Leaner loading: TGMPA actions will now only be hooked in and run on the back-end (`is_admin() returns true`).  [#357] Also most TGMPA actions will now only be hooked in if there's actually something to do for TGMPA. [#381]
   - Fixed: _"Undefined index: skin_update_failed_error"_ [#260], [#240] Thanks [Parhum Khoshbakht] and [Sandeep] for reporting.
+  - Fixed: Installation of bundled plugins with uppercase letters in the plugin slug would fail. [#401], [#403] Thanks [steveboj] for reporting.
   - Made admin URLs environment aware by using `self_admin_url()` instead of `admin_url()` or `network_admin_url()`. [#255], [#171]
   - Fixed: the Adminbar would be loaded twice causing conflicts (with other plugins). [#208] Props [John Blackbourn].
   - All TGMPA generated pages will now show the version number on the page to assist in debugging. [#399], [#402]
@@ -75,7 +117,7 @@ TGMPA will start providing localized text strings soon. If you already have tran
   - Make configurable message texts singular/plural context aware. [#173] Props [Yakir Sitbon].
   - Language strings which are being overridden should use the including plugin/theme language domain. [#217] Props [Christian Foellmann].
   - Language strings are loaded a bit later now to ensure that the translations are loaded beforehand. [#176], [#177] Props [Yakir Sitbon].
-  
+
 * **New action and filter hooks for TGMPA**:
   - `tgmpa_load` - _filter_ can be used to overrule whether TGMPA should load. Defaults to loading only when on the WP back-end when not `DOING_AJAX`. Typical use: `add_filter( 'tgmpa_load', '__return_true' );`.
   - `tgmpa_admin_menu_args` - _filter_ can be used to filter the arguments passed to the function call adding the TGMPA (sub) menu page.
@@ -86,7 +128,7 @@ TGMPA will start providing localized text strings soon. If you already have tran
   - `tgmpa_{$prefix}plugin_action_links` - _filter_ mirrors the WP core [{$prefix}plugin_action_links] filter but for the TGMPA page.
   - `tgmpa_update_bulk_plugins_complete_actions` - _filter_ mirrors the WP core [update_bulk_plugins_complete_actions] filter but for TGMPA bulk actions.
   - `tgmpa_after_plugin_row_{$item['slug']}` - _action_ similar (but not the same) as the WP core [after_plugin_row_{$plugin_file}] action. Can be used to add information to a plugin row in the TGMPA table.
-  
+
   [#188], [#226], [#300], [#357], [#362], [#381], [#388], [#389], [#390] Props [Zack Katz] and the TGMPA team.
 
 * **Housekeeping**:
@@ -94,7 +136,7 @@ TGMPA will start providing localized text strings soon. If you already have tran
      * [#284], [#281] - props [Ninos Ego],
      * [#286] - props [krishna19],
      * [#178], [#180], [#182], [#183] - thanks [Gregory Karpinsky] for reporting,
-     * [#324], [#325], [#331], [#346], [#356], [#357], [#358], [#359], [#360], [#361], [#362], [#363], [#368], [#371], [#373], [#374], [#375], [#376], [#381], [#385], [#387], [#395], [#397]
+     * [#324], [#325], [#331], [#346], [#356], [#357], [#358], [#359], [#360], [#361], [#362], [#363], [#368], [#371], [#373], [#374], [#375], [#376], [#381], [#385], [#387], [#395], [#397], [#425], [#426], [#427], [#435]
   - Allow for extending of the TGMPA class and fixed issues with PHP 5.2 [#303] which were originally caused by this.
   - Tighten the file permissions on our files. [#322]
   - Cleaned up some of the documentation. [#179], [#384] Props [Gregory Karpinsky] and the TGMPA team.
@@ -248,45 +290,116 @@ TGMPA will start providing localized text strings soon. If you already have tran
 
 
 
+[download]: http://tgmpluginactivation.com/download/
+[related blog post]: http://tgmpluginactivation.com/2016/01/15/custom-tgmpa-generator/
 [TGMPA/TGM-Plugin-Activation]: https://github.com/TGMPA/TGM-Plugin-Activation
 [.pot file]: https://github.com/TGMPA/TGM-Plugin-Activation/blob/develop/languages/
 
 
-[Christian Foellmann]: https://github.com/cfoellmann
+[Ahmad Awais]: https://github.com/ahmadawais
+[Chris Howard]: https://github.com/qwertydude
 [Chris Talkington]: https://github.com/ctalkington
+[Christian Foellmann]: https://github.com/cfoellmann
 [Dan Fisher]: https://github.com/danfisher85
+[Denis Žoljom]: https://github.com/dingo-d
 [djcowan]: https://github.com/djcowan
-[Jason Xie]: https://github.com/duckzland
+[Elvis Henrique Pereira]: https://github.com/elvishp2006
+[Emil Uzelac]: https://github.com/emiluzelac
 [Franklin Gitonga]: https://github.com/FrankM1
 [Gary Jones]: https://github.com/GaryJones
+[geoclaps]: https://github.com/geoclaps
+[Gregory Karpinsky]: https://github.com/tivnet
 [hamdan-mahran]: https://github.com/hamdan-mahran
-[Sandeep]: https://github.com/InsertCart
+[Hedi Chaibi]: https://github.com/hedii
+[Jason Xie]: https://github.com/duckzland
 [Jeff Sebring]: https://github.com/jeffsebring
 [John Blackbourn]: https://github.com/johnbillion
 [Juliette Reinders Folmer]: https://github.com/jrfnl
-[Yakir Sitbon]: https://github.com/KingYes
+[Karolína Vyskočilová]: https://github.com/vyskoczilova
 [krishna19]: https://github.com/krishna19
+[Lewis Porter]: https://github.com/lewisporter
 [Luis Martins]: https://github.com/lmartins
 [manake]: https://github.com/manake
+[Mickey Kay]: https://github.com/MickeyKay
+[Mika Epstein]: https://github.com/Ipstenu
+[Mohamed A. Baset]: https://github.com/SymbianSyMoh
 [Nate Wright]: https://github.com/NateWr
 [Ninos Ego]: https://github.com/Ninos
+[Ollie Treend]: https://github.com/ollietreend
 [Parhum Khoshbakht]: https://github.com/parhumm
 [pavot]: https://github.com/pavot
-[Chris Howard]: https://github.com/qwertydude
+[Primoz Cigler]: https://github.com/primozcigler
+[Rami]: https://github.com/ramiy
+[Sandeep]: https://github.com/InsertCart
 [Shiva Poudel]: https://github.com/shivapoudel
+[Stanislav Khromov]: https://github.com/khromov
+[steveboj]: https://github.com/steveboj
 [swiderski]: https://github.com/swiderski
 [tanshcreative]: https://github.com/tanshcreative
 [Tim Nicholson]: https://github.com/timnicholson
-[Thomas Griffin]: https://github.com/thomasgriffin
-[Gregory Karpinsky]: https://github.com/tivnet
 [Travis Smith]: https://github.com/wpsmith
+[Thomas Griffin]: https://github.com/thomasgriffin
+[Utkarsh Patel]: https://github.com/PatelUtkarsh
+[Vladislav Burlak]: https://github.com/vburlak
+[weavertheme]: https://github.com/weavertheme
+[Yakir Sitbon]: https://github.com/KingYes
 [Zack Katz]: https://github.com/zackkatz
 
-[Zauan/Hogash Studio]: http://pastebin.com/u/Zauan
 [Christian]: http://themeforest.net/user/artless
+[Marciel Bartzik]: http://www.bartzik.net/
+[Zauan/Hogash Studio]: http://pastebin.com/u/Zauan
 
-
+[#577]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/577
+[#574]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/574
+[#571]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/571
+[#570]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/570
+[#564]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/564
+[#563]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/563
+[#562]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/562
+[#561]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/561
+[#558]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/558
+[#557]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/557
+[#543]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/543
+[#532]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/532
+[#528]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/528
+[#524]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/524
+[#521]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/521
+[#516]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/516
+[#514]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/514
+[#513]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/513
+[#512]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/512
+[#511]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/511
+[#510]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/510
+[#509]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/509
+[#508]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/508
+[#507]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/507
+[#505]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/505
+[#504]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/504
+[#503]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/503
+[#500]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/500
+[#499]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/499
+[#496]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/496
+[#495]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/495
+[#489]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/489
+[#487]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/487
+[#478]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/478
+[#469]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/469
+[#465]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/465
+[#460]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/460
+[#459]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/459
+[#458]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/458
+[#450]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/450
+[#449]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/449
+[#446]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/446
+[#442]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/442
+[#435]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/435
+[#427]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/427
+[#426]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/426
+[#425]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/425
+[#414]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/414
+[#403]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/403
 [#402]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/402
+[#401]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/401
 [#399]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/399
 [#397]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/397
 [#395]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/395
@@ -356,6 +469,7 @@ TGMPA will start providing localized text strings soon. If you already have tran
 [#203]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/203
 [#197]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/197
 [#192]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/192
+[#190]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/190
 [#188]: https://github.com/TGMPA/TGM-Plugin-Activation/pull/188
 [#185]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/185
 [#183]: https://github.com/TGMPA/TGM-Plugin-Activation/issues/183

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 **Lead Developers:**
 [Thomas Griffin](https://github.com/thomasgriffin) ([@jthomasgriffin](https://twitter.com/jthomasgriffin)), [Gary Jones](https://github.com/GaryJones) ([@GaryJ](https://twitter.com/GaryJ)), [Juliette Reinders Folmer](https://github.com/jrfnl) ([@jrf_nl](https://twitter.com/jrf_nl))  
-**Version:** 2.5.2 
-**Requires at least:** 3.7.0  
-**Tested up to:** 4.2.0  
+**Version:** 2.6.0-RC1 
+**Requires at least:** 3.7.0 
+**Tested up to:** 4.5.2 
 
 ## Description
 

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -88,7 +88,6 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * Holds arrays of plugin details.
 		 *
 		 * @since 1.0.0
-		 *
 		 * @since 2.5.0 the array has the plugin slug as an associative key.
 		 *
 		 * @var array
@@ -3486,8 +3485,8 @@ if ( ! function_exists( 'tgmpa_load_bulk_installer' ) ) {
 				 * @since 2.2.0
 				 *
 				 * {@internal Since 2.5.2 the class has been renamed from TGM_Bulk_Installer_Skin to
-				 *           TGMPA_Bulk_Installer_Skin.
-				 *           This was done to prevent backward compatibility issues with v2.3.6.}}
+				 *            TGMPA_Bulk_Installer_Skin.
+				 *            This was done to prevent backward compatibility issues with v2.3.6.}}
 				 *
 				 * @see https://core.trac.wordpress.org/browser/trunk/src/wp-admin/includes/class-wp-upgrader-skins.php
 				 *
@@ -3815,15 +3814,15 @@ if ( ! class_exists( 'TGMPA_Utils' ) ) {
 
 			if ( is_bool( $value ) ) {
 				return $value;
-			} else if ( is_int( $value ) && ( 0 === $value || 1 === $value ) ) {
+			} elseif ( is_int( $value ) && ( 0 === $value || 1 === $value ) ) {
 				return (bool) $value;
-			} else if ( ( is_float( $value ) && ! is_nan( $value ) ) && ( (float) 0 === $value || (float) 1 === $value ) ) {
+			} elseif ( ( is_float( $value ) && ! is_nan( $value ) ) && ( (float) 0 === $value || (float) 1 === $value ) ) {
 				return (bool) $value;
-			} else if ( is_string( $value ) ) {
+			} elseif ( is_string( $value ) ) {
 				$value = trim( $value );
 				if ( in_array( $value, $true, true ) ) {
 					return true;
-				} else if ( in_array( $value, $false, true ) ) {
+				} elseif ( in_array( $value, $false, true ) ) {
 					return false;
 				} else {
 					return false;

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -1185,7 +1185,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 				$line_template = '<span style="display: block; margin: 0.5em 0.5em 0 0; clear: both;">%s</span>' . "\n";
 
 				if ( ! current_user_can( 'activate_plugins' ) && ! current_user_can( 'install_plugins' ) && ! current_user_can( 'update_plugins' ) ) {
-					$rendered  = esc_html__( $this->strings['notice_cannot_install_activate'] ) . ' ' . esc_html__( $this->strings['contact_admin'] );
+					$rendered  = esc_html( $this->strings['notice_cannot_install_activate'] ) . ' ' . esc_html( $this->strings['contact_admin'] );
 					$rendered .= $this->create_user_action_links_for_notice( 0, 0, 0, $line_template );
 				} else {
 

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -281,6 +281,8 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 *
 		 * @see https://github.com/TGMPA/TGM-Plugin-Activation/blob/2.3.6/tgm-plugin-activation/class-tgm-plugin-activation.php#L1593
 		 *
+		 * @since 2.5.2
+		 *
 		 * @param string $name  Name of an inaccessible property.
 		 * @param mixed  $value Value to assign to the property.
 		 * @return void  Silently fail to set the property when this is tried from outside of this class context.
@@ -292,6 +294,8 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 
 		/**
 		 * Magic method to get the value of a protected property outside of this class context.
+		 *
+		 * @since 2.5.2
 		 *
 		 * @param string $name Name of an inaccessible property.
 		 * @return mixed The property value.
@@ -2060,6 +2064,8 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 
 		/**
 		 * Echo the current TGMPA version number to the page.
+		 *
+		 * @since 2.5.0
 		 */
 		public function show_tgmpa_version() {
 			echo '<p style="float: right; padding: 0em 1.5em 0.5em 0;"><strong><small>',
@@ -2092,6 +2098,8 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 	if ( ! function_exists( 'load_tgm_plugin_activation' ) ) {
 		/**
 		 * Ensure only one instance of the class is ever invoked.
+		 *
+		 * @since 2.5.0
 		 */
 		function load_tgm_plugin_activation() {
 			$GLOBALS['tgmpa'] = TGM_Plugin_Activation::get_instance();
@@ -3103,6 +3111,11 @@ if ( ! class_exists( 'TGM_Bulk_Installer' ) ) {
 
 	/**
 	 * Hack: Prevent TGMPA v2.4.1- bulk installer class from being loaded if 2.4.1- is loaded after 2.5+.
+	 *
+	 * @since 2.5.2
+	 *
+	 * {@internal The TGMPA_Bulk_Installer class was originally called TGM_Bulk_Installer.
+	 *            For more information, see that class.}}
 	 */
 	class TGM_Bulk_Installer {
 	}
@@ -3111,6 +3124,11 @@ if ( ! class_exists( 'TGM_Bulk_Installer_Skin' ) ) {
 
 	/**
 	 * Hack: Prevent TGMPA v2.4.1- bulk installer skin class from being loaded if 2.4.1- is loaded after 2.5+.
+	 *
+	 * @since 2.5.2
+	 *
+	 * {@internal The TGMPA_Bulk_Installer_Skin class was originally called TGM_Bulk_Installer_Skin.
+	 *            For more information, see that class.}}
 	 */
 	class TGM_Bulk_Installer_Skin {
 	}

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -8,7 +8,7 @@
  * or theme author for support.
  *
  * @package   TGM-Plugin-Activation
- * @version   2.5.2
+ * @version   2.6.0
  * @link      http://tgmpluginactivation.com/
  * @author    Thomas Griffin, Gary Jones, Juliette Reinders Folmer
  * @copyright Copyright (c) 2011, Thomas Griffin
@@ -55,7 +55,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 *
 		 * @const string Version number.
 		 */
-		const TGMPA_VERSION = '2.5.2';
+		const TGMPA_VERSION = '2.6.0';
 
 		/**
 		 * Regular expression to test if a URL is a WP plugin repo URL.
@@ -456,7 +456,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		/**
 		 * Load translations.
 		 *
-		 * @since 2.x.x
+		 * @since 2.6.0
 		 *
 		 * (@internal Uses `load_theme_textdomain()` rather than `load_plugin_textdomain()` to
 		 * get round the different ways of handling the path and deprecated notices being thrown
@@ -488,7 +488,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * {@internal IMPORTANT! If this function changes, review the regex in the custom TGMPA
 		 * generator on the website.}}
 		 *
-		 * @since 2.x.x
+		 * @since 2.6.0
 		 *
 		 * @param string $mofile Full path to the target mofile.
 		 * @param string $domain The domain for which a language file is being loaded.
@@ -515,7 +515,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * {@internal IMPORTANT! If this function changes, review the regex in the custom TGMPA
 		 * generator on the website.}}
 		 *
-		 * @since 2.x.x
+		 * @since 2.6.0
 		 *
 		 * @param string $mofile Full path to the target mofile.
 		 * @param string $domain The domain for which a language file is being loaded.
@@ -1241,7 +1241,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		/**
 		 * Generate the user action links for the admin notice.
 		 *
-		 * @since 2.x.x
+		 * @since 2.6.0
 		 *
 		 * @param int $install_count  Number of plugins to install.
 		 * @param int $update_count   Number of plugins to update.
@@ -1303,7 +1303,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * Work around all the changes to the various admin notice classes between WP 4.4 and 3.7
 		 * (lowest supported version by TGMPA).
 		 *
-		 * @since 2.x.x
+		 * @since 2.6.0
 		 *
 		 * @return string
 		 */
@@ -1716,7 +1716,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		/**
 		 * Determine if we're on a WP Core installation/upgrade page.
 		 *
-		 * @since 2.x.x
+		 * @since 2.6.0
 		 *
 		 * @return boolean True when on a WP Core installation/upgrade page, false otherwise.
 		 */
@@ -1865,7 +1865,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 * Check to see if the plugin is 'updatetable', i.e. installed, with an update available
 		 * and no WP version requirements blocking it.
 		 *
-		 * @since 2.x.x
+		 * @since 2.6.0
 		 *
 		 * @param string $slug Plugin slug.
 		 * @return bool True if OK to proceed with update, false otherwise.

--- a/example.php
+++ b/example.php
@@ -10,7 +10,7 @@
  *
  * @package    TGM-Plugin-Activation
  * @subpackage Example
- * @version    2.5.2
+ * @version    2.6.0
  * @author     Thomas Griffin, Gary Jones, Juliette Reinders Folmer
  * @copyright  Copyright (c) 2011, Thomas Griffin
  * @license    http://opensource.org/licenses/gpl-2.0.php GPL v2 or later

--- a/example.php
+++ b/example.php
@@ -201,7 +201,7 @@ function my_theme_register_required_plugins() {
 			'plugin_needs_higher_version'     => __( 'Plugin not activated. A higher version of %s is needed for this theme. Please update the plugin.', 'theme-slug' ),
 			/* translators: 1: dashboard link. * /
 			'complete'                        => __( 'All plugins installed and activated successfully. %1$s', 'theme-slug' ),
-			'dismiss'                         => __( 'Dismiss this notice', 'tgmpa' ),
+			'dismiss'                         => __( 'Dismiss this notice', 'theme-slug' ),
 			'notice_cannot_install_activate'  => __( 'There are one or more required or recommended plugins to install, update or activate.', 'theme-slug' ),
 			'contact_admin'                   => __( 'Please contact the administrator of this site for help.', 'theme-slug' ),
 


### PR DESCRIPTION
Updated changelog for v2.6.0, upped version nrs.

Also:
* Added version nr to `@since` tags for new functions.
* Added missing `@since` tags for some functions and classes from the 2.5.x range.
* Fix text-domain for a string in the example file.
* Don't try to translate already translated strings. (Remove `__()`)
* Minor code-style tidying up.
* Added some missing changes from the 2.5.0 release.
* Added the GH issue nrs to the 2.5.1 and 2.5.2 release changelog.

Closes #556