### PR TITLE
Use correct directory path

### DIFF
--- a/example.php
+++ b/example.php
@@ -20,7 +20,7 @@
 /**
  * Include the TGM_Plugin_Activation class.
  */
-require_once dirname( __FILE__ ) . '/class-tgm-plugin-activation.php';
+require_once get_template_directory() . '/class-tgm-plugin-activation.php';
 
 add_action( 'tgmpa_register', 'my_theme_register_required_plugins' );
 /**
@@ -48,7 +48,7 @@ function my_theme_register_required_plugins() {
 		array(
 			'name'               => 'TGM Example Plugin', // The plugin name.
 			'slug'               => 'tgm-example-plugin', // The plugin slug (typically the folder name).
-			'source'             => get_stylesheet_directory() . '/lib/plugins/tgm-example-plugin.zip', // The plugin source.
+			'source'             => get_template_directory() . '/lib/plugins/tgm-example-plugin.zip', // The plugin source.
 			'required'           => true, // If false, the plugin is only 'recommended' instead of required.
 			'version'            => '', // E.g. 1.0.0. If set, the active plugin must be this version or higher. If the plugin version is higher than the plugin version installed, the user will be notified to update the plugin.
 			'force_activation'   => false, // If true, plugin is activated upon theme activation and cannot be deactivated until theme switch.


### PR DESCRIPTION
`get_template_directory()` should be used in both cases. 

- get_template_directory(): Returns the absolute template directory path.
- get_stylesheet_directory(): Returns the absolute stylesheet directory path.

Maybe you could recommend https://wordpress.org/plugins/example/ instead of one that bundles.