### PR TITLE
Fix i18n functions

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -2466,7 +2466,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @since 2.2.0
 		 */
 		public function no_items() {
-			echo wp_kses_post( esc_html__( 'No plugins to install, update or activate.', 'tgmpa' ) . ' <a href="' . esc_url( self_admin_url() ) . '"> ' . esc_html__( 'Return to the Dashboard', 'tgmpa' ) . '</a>' );
+			echo esc_html__( 'No plugins to install, update or activate.', 'tgmpa' ) . ' <a href="' . esc_url( self_admin_url() ) . '"> ' . esc_html__( 'Return to the Dashboard', 'tgmpa' ) . '</a>';
 			echo '<style type="text/css">#adminmenu .wp-submenu li.current { display: none !important; }</style>';
 		}
 

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -1918,7 +1918,13 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 		 */
 		public function show_tgmpa_version() {
 			echo '<p style="float: right; padding: 0em 1.5em 0.5em 0;"><strong><small>',
-				esc_html( sprintf( _x( 'TGMPA v%s', '%s = version number', 'tgmpa' ), self::TGMPA_VERSION ) ),
+				esc_html(
+					sprintf(
+						/* translators: %s: version number */
+						__( 'TGMPA v%s', 'tgmpa' ),
+						self::TGMPA_VERSION
+					)
+				),
 				'</small></strong></p>';
 		}
 
@@ -2272,7 +2278,8 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 			}
 
 			return sprintf(
-				_x( '%1$s, %2$s', '%1$s = install status, %2$s = update status', 'tgmpa' ),
+				/* translators: %1$s: install status, %2$s: update status */
+				__( '%1$s, %2$s', 'tgmpa' ),
 				$install_status,
 				$update_status
 			);
@@ -2528,16 +2535,19 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 
 			// Display the 'Install' action link if the plugin is not yet available.
 			if ( ! $this->tgmpa->is_plugin_installed( $item['slug'] ) ) {
-				$actions['install'] = _x( 'Install %2$s', '%2$s = plugin name in screen reader markup', 'tgmpa' );
+				/* translators: %s: plugin name in screen reader markup */
+				$actions['install'] = __( 'Install %s', 'tgmpa' );
 			} else {
 				// Display the 'Update' action link if an update is available and WP complies with plugin minimum.
 				if ( false !== $this->tgmpa->does_plugin_have_update( $item['slug'] ) && $this->tgmpa->can_plugin_update( $item['slug'] ) ) {
-					$actions['update'] = _x( 'Update %2$s', '%2$s = plugin name in screen reader markup', 'tgmpa' );
+					/* translators: %s: plugin name in screen reader markup */
+					$actions['update'] = __( 'Update %s', 'tgmpa' );
 				}
 
 				// Display the 'Activate' action link, but only if the plugin meets the minimum version.
 				if ( $this->tgmpa->can_plugin_activate( $item['slug'] ) ) {
-					$actions['activate'] = _x( 'Activate %2$s', '%2$s = plugin name in screen reader markup', 'tgmpa' );
+					/* translators: %s: plugin name in screen reader markup */
+					$actions['activate'] = __( 'Activate %s', 'tgmpa' );
 				}
 			}
 

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -2466,7 +2466,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 		 * @since 2.2.0
 		 */
 		public function no_items() {
-			printf( wp_kses_post( __( 'No plugins to install, update or activate. <a href="%1$s">Return to the Dashboard</a>', 'tgmpa' ) ), esc_url( self_admin_url() ) );
+			echo wp_kses_post( esc_html__( 'No plugins to install, update or activate.', 'tgmpa' ) . ' <a href="' . esc_url( self_admin_url() ) . '"> ' . esc_html__( 'Return to the Dashboard', 'tgmpa' ) . '</a>' );
 			echo '<style type="text/css">#adminmenu .wp-submenu li.current { display: none !important; }</style>';
 		}
 

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -2279,7 +2279,7 @@ if ( ! class_exists( 'TGMPA_List_Table' ) ) {
 
 			return sprintf(
 				/* translators: %1$s: install status, %2$s: update status */
-				__( '%1$s, %2$s', 'tgmpa' ),
+				_x( '%1$s, %2$s', 'Install/Update Status', 'tgmpa' ),
 				$install_status,
 				$update_status
 			);

--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -370,7 +370,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 					'tgmpa'
 				),
 				'return'                          => __( 'Return to Required Plugins Installer', 'tgmpa' ),
-				'dashboard'                       => __( 'Return to the dashboard', 'tgmpa' ),
+				'dashboard'                       => __( 'Return to the Dashboard', 'tgmpa' ),
 				'plugin_activated'                => __( 'Plugin activated successfully.', 'tgmpa' ),
 				'activated_successfully'          => __( 'The following plugin was activated successfully:', 'tgmpa' ),
 				'plugin_already_active'           => __( 'No action taken. Plugin %1$s was already active.', 'tgmpa' ),


### PR DESCRIPTION
In WordPress 4.4 [we fixed many translation functions in the core](https://core.trac.wordpress.org/query?milestone=4.4&component=I18N&reporter=ramiy&groupdesc=1&group=milestone&col=id&col=summary&col=reporter&col=milestone&col=type&col=component&order=priority). The same coding standards should be implemented in TGM too.