### PR TITLE
Revert "Bypass latest Theme Check update for add_submenu_page calls."

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -618,8 +618,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			if ( 'themes.php' === $this->parent_slug ) {
 				$this->page_hook = call_user_func( 'add_theme_page', $args['page_title'], $args['menu_title'], $args['capability'], $args['menu_slug'], $args['function'] );
 			} else {
-				$type = 'submenu';
-				$this->page_hook = call_user_func( "add_{$type}_page", $args['parent_slug'], $args['page_title'], $args['menu_title'], $args['capability'], $args['menu_slug'], $args['function'] );
+				$this->page_hook = call_user_func( 'add_submenu_page', $args['parent_slug'], $args['page_title'], $args['menu_title'], $args['capability'], $args['menu_slug'], $args['function'] );
 			}
 		}
 


### PR DESCRIPTION
This reverts commit 9896b4438230770acf556fcf70e109aabea91e59.

With the addition of the Custom TGMPA Generator (PR #519) to the website, this hack is not needed anymore and reverting it will simplify the actual work the Custom TGMPA Generator will need to do (no need for different regexes for TGMPA v 2.5.2 and 2.6.0).