### PR TITLE
Improved Atom feed template.

### DIFF
--- a/atom.xml
+++ b/atom.xml
@@ -7,17 +7,36 @@ sitemap:
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
 	<title>{{ site.tgmpa.title }}</title>
-	<link href="{{ '/atom.xml' | prepend: site.tgmpa.url }}" rel="self" />
-	<link href="{{ site.tgmpa.url }}" />
+	<link href="{{ '/atom.xml' | prepend: site.tgmpa.url }}" rel="self" type="application/atom+xml" />
+	<link href="{{ '/' | prepend: site.tgmpa.url }}" rel="alternate" type="text/html" />
 	<updated>{{ site.time | date_to_xmlschema }}</updated>
-	<id>{{ site.tgmpa.url }}</id>
-	{% for post in site.posts limit:15 %}
+	<id>{{ '/' | prepend: site.tgmpa.url | xml_escape }}</id>
+	{% for post in site.posts limit: 15 %}
 	<entry>
-		<id>{{ post.id | prepend: site.tgmpa.url }}</id>
-		<title>{{ post.title | xml_escape }}</title>
-		<link href="{{ post.url | remove: 'index.html' | prepend: site.tgmpa.url }}" />
+		<id>{{ post.id | prepend: site.tgmpa.url | xml_escape }}</id>
+		<title>{{ post.title | markdownify | strip_html | replace: '\n', ' ' | strip | xml_escape }}</title>
+		<link href="{{ post.url | remove: 'index.html' | prepend: site.tgmpa.url }}" rel="alternate" type="text/html" title="{{ post.title | xml_escape }}" />
 		<published>{{ post.date | date_to_xmlschema }}</published>
-		<content type="html">{{ post.content | xml_escape }}</content>
+		<content type="html" xml:base="{{ post.url | prepend: site.tgmpa.url | xml_escape }}">{{ post.content | xml_escape }}</content>
+		{% if post.author %}
+		<author>
+			{% if post.author.name %}
+			<name>{{ post.author.name | xml_escape }}</name>
+			{% else %}
+			<name>{{ post.author | xml_escape }}</name>
+			{% endif %}
+			{% if post.author.email %}
+			<email>{{ post.author.email | xml_escape }}</email>
+			{% endif %}
+			{% if post.author.uri %}
+			<uri>{{ post.author.uri | xml_escape }}</uri>
+			{% endif %}
+		</author>
+		{% endif %}
+		{% for category in post.categories %}
+		<category term="{{ category | xml_escape }}" />{% endfor %}
+		{% for tag in post.tags %}
+		<category term="{{ tag | xml_escape }}" />{% endfor %}
 	</entry>
 	{% endfor %}
 </feed>


### PR DESCRIPTION
More relevant now there are blog posts.

Also tested the [standard feed generation gem](https://help.github.com/articles/atom-rss-feeds-for-github-pages/) again, but this fails to parse the markdown properly and gives relative - and therefore incorrect - urls, so using our own template is still the best solution.