### PR TITLE
Fix @since tag of a filter.

### DIFF
--- a/class-tgm-plugin-activation.php
+++ b/class-tgm-plugin-activation.php
@@ -1443,7 +1443,7 @@ if ( ! class_exists( 'TGM_Plugin_Activation' ) ) {
 			/**
 			* Filter a sanitized key string.
 			*
-			* @since 3.0.0
+			* @since 2.5.0
 			*
 			* @param string $key     Sanitized key.
 			* @param string $raw_key The key prior to sanitization.


### PR DESCRIPTION
The filter is taken from WP core and was introduced in WP core in WP 3.0.0, but introduced in TGMPA in TGMPA 2.5.